### PR TITLE
set-value

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "ngx-material-timepicker": "^3.3.0",
     "rxjs": "~6.4.0",
     "tslib": "^1.9.0",
-    "zone.js": "~0.9.1"
+    "zone.js": "~0.9.1",
+    "serialize-javascript": "~3.0.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.800.0",
@@ -47,6 +48,7 @@
     "protractor": "~5.4.0",
     "ts-node": "~7.0.0",
     "tslint": "~5.15.0",
-    "typescript": "~3.4.3"
+    "typescript": "~3.4.3",
+    "serialize-javascript": "~3.0.0"
   }
 }


### PR DESCRIPTION
CVE-2019-10747
Vulnerable versions: < 2.0.1 Patched version: 2.0.1 set-value is vulnerable to Prototype Pollution in versions before 2.0.1 and version 3.0.0. The function mixin-deep could be tricked into adding or modifying properties of Object.prototype using any of the constructor, prototype and proto payloads.