### PR TITLE
serialize-javascript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -149,6 +149,7 @@
         "tslib": "^1.7.1"
       },
       "dependencies": {
+        "serialize-javascript": ">=2.1.1"
         "parse5": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",


### PR DESCRIPTION
GHSA-h9rv-jmmf-4pgx
moderate severity
Vulnerable versions: < 2.1.1
Patched version: 2.1.1
regular expressions Cross-Site Scripting (XSS) vulnerability
Impact
Affected versions of this package are vulnerable to Cross-site Scripting (XSS). It does not properly mitigate against unsafe characters in serialized regular expressions.

This vulnerability is not affected on Node.js environment since Node.js's implementation of RegExp.prototype.toString() backslash-escapes all forward slashes in regular expressions.

If serialized data of regular expression objects are used in an environment other than Node.js, it is affected by this vulnerability.

Patches
This was patched in v2.1.1.